### PR TITLE
fix: pencarian tiket

### DIFF
--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -361,7 +361,6 @@ class TicketResource extends Resource
                     'record' => $record,      // opsional kalau view kamu masih butuh $record
                 ])
                 ->sortable()
-                ->searchable()
                 ->disabledClick(),
 
             // Kolom penanggung jawab
@@ -378,7 +377,6 @@ class TicketResource extends Resource
                     'record' => $record,      // opsional kalau view kamu masih butuh $record
                 ])
                 ->sortable()
-                ->searchable()
                 ->disabledClick(),
 
             // Kolom status


### PR DESCRIPTION
## Deskripsi
### Problem

- Error SQL saat melakukan pencarian: Unknown column 'owner' in 'where clause'
- Terjadi karena Filament mencoba search di kolom yang tidak ada

### Root Cause

- ViewColumn::make('owner')->searchable() mencoba search di kolom tickets.owner (tidak ada)
- ViewColumn::make('responsible')->searchable() mencoba search di kolom tickets.responsible (tidak ada)
- Kolom yang sebenarnya ada: owner_id dan responsible_id

### Solution

- Menghapus ->searchable() dari kedua ViewColumn
- ViewColumn tetap berfungsi untuk menampilkan avatar user
- Filter dropdown untuk Owner dan Responsible tetap tersedia

### Changes

- Modified: `app/Filament/Resources/TicketResource.php`
- Menghapus 2 baris ->searchable() dari owner dan responsible columns

## Untuk issue:
- https://github.com/OpenSID/help-desk/issues/56